### PR TITLE
feat(member): 회원 프로필 업데이트 기능 구현

### DIFF
--- a/src/main/java/com/shingu/roadmap/member/controller/MemberController.java
+++ b/src/main/java/com/shingu/roadmap/member/controller/MemberController.java
@@ -1,13 +1,25 @@
 package com.shingu.roadmap.member.controller;
 
+import com.shingu.roadmap.member.dto.request.ProfileRequest;
+import com.shingu.roadmap.member.dto.response.MemberResponse;
 import com.shingu.roadmap.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
 
 @RestController
 @RequiredArgsConstructor
-public class MemberController {
-    private  final  MemberService memberService;
+public class MemberController implements MemberControllerSwagger {
+    private final MemberService memberService;
 
-
+    @Override
+    @PutMapping("/api/v1/member/{id}/profile")
+    public ResponseEntity<MemberResponse> updateProfile(
+            @PathVariable Long id,
+            @RequestBody ProfileRequest profileRequest
+    ) {
+        MemberResponse response = memberService.updateProfile(id, profileRequest);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/shingu/roadmap/member/controller/MemberControllerSwagger.java
+++ b/src/main/java/com/shingu/roadmap/member/controller/MemberControllerSwagger.java
@@ -1,0 +1,25 @@
+package com.shingu.roadmap.member.controller;
+
+import com.shingu.roadmap.member.dto.request.ProfileRequest;
+import com.shingu.roadmap.member.dto.response.MemberResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Member API", description = "회원 관련 API")
+public interface MemberControllerSwagger {
+  @Operation(
+          summary = "회원 프로필 정보 추가",
+          responses = {
+                  @ApiResponse(
+                          responseCode = "200",
+                          description = "회원 프로필 추가 성공",
+                          content = @Content(schema = @Schema(implementation = MemberResponse.class))
+                  ),
+          }
+  )
+  ResponseEntity<MemberResponse> updateProfile(Long id, ProfileRequest profileRequest);
+}

--- a/src/main/java/com/shingu/roadmap/member/domain/Member.java
+++ b/src/main/java/com/shingu/roadmap/member/domain/Member.java
@@ -1,12 +1,14 @@
 package com.shingu.roadmap.member.domain;
 
 import com.shingu.roadmap.common.domain.BaseEntity;
+import com.shingu.roadmap.member.dto.request.ProfileRequest;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -16,11 +18,12 @@ import java.util.Set;
 @Getter
 public class Member extends BaseEntity {
 
-    private String name;
-    private String phoneNumber;
+    private String name; // 이름
+    private String phoneNumber; // 전화번호
+    private LocalDate birthDate; // 생년월일
 
     @Embedded
-    private Profile profile;
+    private Profile profile; // 프로필 정보
 
     @ElementCollection
     @CollectionTable(name = "member_skill", joinColumns = @JoinColumn(name = "member_id"))
@@ -36,4 +39,47 @@ public class Member extends BaseEntity {
     @CollectionTable(name = "member_ncs", joinColumns = @JoinColumn(name = "member_id"))
     @Column(name = "ncs_code")
     private Set<String> ncsCodes = new HashSet<>(); // 국가직무능력표준 코드 목록
+
+    /**
+     * 보유 기술 목록을 초기화 후 등록합니다.
+     * @param skills
+     */
+    public void updateSkills(Set<String> skills) {
+        this.skills.clear();
+        if (skills != null) {
+            this.skills.addAll(skills);
+        }
+    }
+
+    /**
+     * 자격증 목록을 초기화 후 등록합니다.
+     * @param certificates
+     */
+    public void updateCertificates(Set<String> certificates) {
+        this.certificates.clear();
+        if (certificates != null) {
+            this.certificates.addAll(certificates);
+        }
+    }
+
+    /**
+     * 회원 프로필 정보를 업데이트합니다.
+     * @param request
+     */
+    public void applyProfile(ProfileRequest request) {
+        this.profile = new Profile(
+                request.educationLevel(),
+                request.major(),
+                request.desiredJob()
+        );
+        updateSkills(request.skills());
+        updateCertificates(request.certificates());
+    }
+
+    public void updateNcsCodes(Set<String> ncsCodes) {
+        this.ncsCodes.clear();
+        if (ncsCodes != null) {
+            this.ncsCodes.addAll(ncsCodes);
+        }
+    }
 }

--- a/src/main/java/com/shingu/roadmap/member/service/MemberService.java
+++ b/src/main/java/com/shingu/roadmap/member/service/MemberService.java
@@ -18,7 +18,6 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class MemberService {
     private final MemberRepository memberRepository;
-    private final OpenAiService openAiService;
 
     @Transactional
     public MemberResponse updateProfile(Long memberId, ProfileRequest request) {

--- a/src/main/java/com/shingu/roadmap/member/service/MemberService.java
+++ b/src/main/java/com/shingu/roadmap/member/service/MemberService.java
@@ -11,7 +11,6 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.security.PrivateKey;
 import java.util.Set;
 import java.util.stream.Collectors;
 

--- a/src/main/java/com/shingu/roadmap/member/service/MemberService.java
+++ b/src/main/java/com/shingu/roadmap/member/service/MemberService.java
@@ -1,11 +1,34 @@
 package com.shingu.roadmap.member.service;
 
+import com.shingu.roadmap.apis.openai.service.OpenAiService;
+import com.shingu.roadmap.member.domain.Member;
+import com.shingu.roadmap.member.domain.Profile;
+import com.shingu.roadmap.member.dto.request.ProfileRequest;
+import com.shingu.roadmap.member.dto.response.MemberResponse;
 import com.shingu.roadmap.member.repository.MemberRepository;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.security.PrivateKey;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class MemberService {
-    private  final MemberRepository memberRepository;
+    private final MemberRepository memberRepository;
+    private final OpenAiService openAiService;
+
+    @Transactional
+    public MemberResponse updateProfile(Long memberId, ProfileRequest request) {
+        Member member = memberRepository.findById(memberId)
+                .filter(m -> m.getDeletedAt() == null)
+                .orElseThrow(() -> new EntityNotFoundException("Member not found"));
+
+        member.applyProfile(request);
+
+        return MemberResponse.from(member);
+    }
 }


### PR DESCRIPTION
- 회원 프로필 정보를 업데이트하는 기능을 추가했습니다.
- MemberController에 프로필 업데이트 API를 구현하고,
- MemberService에서 프로필 업데이트 로직을 처리합니다.
- Member 도메인에 프로필 적용 메서드를 추가했습니다.