### PR TITLE
refactor(ProfileCertificate): Remove unused initializeId method

### DIFF
--- a/src/main/java/com/shingu/roadmap/member/domain/ProfileCertificate.java
+++ b/src/main/java/com/shingu/roadmap/member/domain/ProfileCertificate.java
@@ -43,17 +43,6 @@ public class ProfileCertificate {
     this.acquiredYear = normalize(acquiredYear);
   }
 
-  @PrePersist
-  private void initializeId() {
-    if (this.id == null) {
-      this.id = new ProfileCertificateId();
-    }
-    if (this.profile != null && this.certificate != null) {
-      this.id.setProfileId(this.profile.getId());
-      this.id.setCertificateId(this.certificate.getJmcd());
-    }
-  }
-
   public static ProfileCertificate of(Profile profile, Certificate certificate, String acquiredYear) {
     return ProfileCertificate.builder()
             .profile(profile)


### PR DESCRIPTION
- initializeId 메서드를 제거하여 코드 간결성을 높임.
- 해당 메서드는 더 이상 필요하지 않음.

Closes: #50