### PR TITLE
Feature/OpenAI/caching

### DIFF
--- a/src/main/java/com/shingu/roadmap/apis/openai/cache/EventPublishingCacheManager.java
+++ b/src/main/java/com/shingu/roadmap/apis/openai/cache/EventPublishingCacheManager.java
@@ -12,6 +12,8 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 
 import java.util.Collection;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * 이벤트를 발행하는 CacheManager 래퍼
@@ -178,6 +180,32 @@ public class EventPublishingCacheManager implements CacheManager {
             } catch (Exception e) {
                 log.debug("캐시 Clear 이벤트 발행 실패: {}", e.getMessage());
             }
+        }
+
+        @Override
+        public CompletableFuture<Cache.ValueWrapper> retrieve(Object key) {
+            // Explicitly cast to resolve generic type mismatch
+            CompletableFuture<ValueWrapper> future = Objects.requireNonNull(delegateCache.retrieve(key))
+                    .thenApply(result -> (ValueWrapper) result);
+
+            future.whenComplete((valueWrapper, throwable) -> {
+                try {
+                    if (throwable != null) {
+                        log.debug("캐시 retrieve 실패: {}", throwable.getMessage());
+                        return;
+                    }
+
+                    if (valueWrapper != null) {
+                        eventPublisher.publishEvent(new CacheHitEvent(this, cacheName, key, extractOperationFromStack()));
+                    } else {
+                        eventPublisher.publishEvent(new CacheMissEvent(this, cacheName, key, extractOperationFromStack()));
+                    }
+                } catch (Exception e) {
+                    log.debug("캐시 retrieve 이벤트 발행 실패: {}", e.getMessage());
+                }
+            });
+
+            return future;
         }
 
         /**

--- a/src/main/java/com/shingu/roadmap/apis/openai/config/OpenAiClientConfig.java
+++ b/src/main/java/com/shingu/roadmap/apis/openai/config/OpenAiClientConfig.java
@@ -20,7 +20,7 @@ public class OpenAiClientConfig {
             .build();
 
     return WebClient.builder()
-            .baseUrl(config.getBaseUrl())
+            .baseUrl(config.getBaseUrl() + "/v1")
             .exchangeStrategies(strategies)
             .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + config.getApiKey())
             .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/com/shingu/roadmap/member/domain/Profile.java
+++ b/src/main/java/com/shingu/roadmap/member/domain/Profile.java
@@ -63,14 +63,14 @@ public class Profile {
   @Builder.Default
   private Set<ProfileSkill> profileSkills = new HashSet<>();
 
-  @ManyToMany(fetch = FetchType.LAZY)
+  @ManyToMany(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.MERGE})
   @JoinTable(name = "profile_desired_ncs",
           joinColumns = @JoinColumn(name = "profile_id"),
           inverseJoinColumns = @JoinColumn(name = "ncs_code"))
   @Builder.Default
   private Set<NcsOccupation> desiredCapabilities = new HashSet<>();
 
-  @ManyToMany(fetch = FetchType.LAZY)
+  @ManyToMany(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.MERGE})
   @JoinTable(name = "profile_user_ncs",
           joinColumns = @JoinColumn(name = "profile_id"),
           inverseJoinColumns = @JoinColumn(name = "ncs_code"))


### PR DESCRIPTION
This pull request introduces several improvements and fixes across caching, API configuration, and entity persistence. The main changes enhance cache event publishing, update the OpenAI client configuration, and improve JPA entity relationship management.

**Caching enhancements:**

* Added a new `retrieve` method to the `EventPublishingCacheManager.CacheWrapper` class that returns a `CompletableFuture`, handles cache hits and misses, and publishes corresponding events. This improves cache observability and error handling.
* Imported `Objects` and `CompletableFuture` to support the new asynchronous cache retrieval logic.

**API configuration update:**

* Changed the base URL in `OpenAiClientConfig.openAiWebClient` to append `/v1`, ensuring requests are sent to the correct versioned endpoint.

**Entity persistence improvements:**

* Added `cascade = {CascadeType.PERSIST, CascadeType.MERGE}` to the `desiredCapabilities` and `userCapabilities` `@ManyToMany` relationships in the `Profile` entity, ensuring related entities are properly persisted and merged with profile updates.