### PR TITLE
feat(jwt): Add JTI claim for token uniqueness

### DIFF
--- a/src/main/java/com/shingu/roadmap/security/jwt/JwtUtil.java
+++ b/src/main/java/com/shingu/roadmap/security/jwt/JwtUtil.java
@@ -34,6 +34,7 @@ public class JwtUtil {
 
     return Jwts.builder()
             .setClaims(claims)
+            .setId(UUID.randomUUID().toString()) // JTI (JWT ID) 클레임 설정으로 토큰 고유성 보장
             .setSubject(payload.memberId().toString())
             .setIssuer(jwtProperties.getIssuer())
             .setAudience(jwtProperties.getAudience())


### PR DESCRIPTION
- JWT 생성 시 JTI (JWT ID) 클레임을 설정하여 토큰의 고유성을 보장합니다.
- 이를 통해 토큰 관리 및 검증 과정에서 보다 안전한 처리가 가능합니다.